### PR TITLE
Clone submodule with HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nanshe_workflow"]
 	path = nanshe_workflow
-	url = git@github.com:nanshe-org/nanshe_workflow.git
+	url = https://github.com/nanshe-org/nanshe_workflow.git


### PR DESCRIPTION
Uses HTTPS for cloning the submodule instead of SSH.