### PR TITLE
Fix conda environment removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python${PYTHON_VERSION} -m ipyparallel.apps.ipclusterapp nbextension enable && \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
+        conda${PYTHON_VERSION} remove -qy -n _build --all || true && \
         conda${PYTHON_VERSION} remove -qy -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all && \
         conda${PYTHON_VERSION} remove -qy -n _test --all && \
         conda${PYTHON_VERSION} clean -tipsy ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,3 @@ RUN rm -f /tmp/test.sh && \
 
 WORKDIR /nanshe_workflow
 ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--no-browser", "--ip=*" ]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
         conda${PYTHON_VERSION} remove -qy -n _build --all || true && \
         conda${PYTHON_VERSION} remove -qy -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all && \
-        conda${PYTHON_VERSION} remove -qy -n _test --all && \
+        conda${PYTHON_VERSION} remove -qy -n _test --all || true && \
         conda${PYTHON_VERSION} clean -tipsy ; \
     done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,3 +71,4 @@ RUN rm -f /tmp/test.sh && \
 
 WORKDIR /nanshe_workflow
 ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--no-browser", "--ip=*" ]
+


### PR DESCRIPTION
`conda` has gotten more sensitive about removing environments that don't exist. Before it silently passed over them. Now it errors out. Here we make some changes so that those errors are suppressed as they should not break the build.

Note: This should fix build failures like this [one]( https://quay.io/repository/nanshe/nanshe_workflow/build/91aec8fc-63f9-4be4-9054-1cfd22e5f06c ).