### PR TITLE
Drop `-f` from `docker tag` calls

### DIFF
--- a/startup_nanshe_workflow.py
+++ b/startup_nanshe_workflow.py
@@ -155,7 +155,7 @@ class Docker(object):
         image_old = ":".join(image_old)
 
         try:
-            subprocess.call(["docker", "tag", "-f", image, image_old])
+            subprocess.call(["docker", "tag", image, image_old])
             subprocess.check_call(["docker", "pull", image])
         finally:
             subprocess.call(["docker", "rmi", image_old])
@@ -170,7 +170,7 @@ class Docker(object):
         image_old = ":".join(image_old)
 
         try:
-            subprocess.call(["docker", "tag", "-f", image, image_old])
+            subprocess.call(["docker", "tag", image, image_old])
             subprocess.check_call([
                 "docker", "build", "--rm", "-t", image, path
             ])


### PR DESCRIPTION
We no longer need to add the `-f` flag to `docker tag` to overwrite a tag. Instead `docker tag` now always acts with force. Since 1.10 this hasn't been required, but as of 1.12 it is actually an error, which is a problem for us. So we now drop it.

xref: https://github.com/docker/docker/pull/18350