### PR TITLE
Ignore other `.py[cod]` files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Ignore compiled Python code.
 __pycache__
-startup_nanshe_workflow.py[cod]
+*.py[cod]
 
 # Ignore develop install products.
 startup_nanshe_workflow.egg-info/


### PR DESCRIPTION
Was missing some other `*.py[cod]` files. This generalizes that pattern to catch the other files too.