### PR TITLE
Allow Jupyter Notebook's to be run as `root`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,4 @@ RUN rm -f /tmp/test.sh && \
     rm /tmp/test.sh
 
 WORKDIR /nanshe_workflow
-ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--no-browser", "--ip=*" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" ]


### PR DESCRIPTION
We probably shouldn't be running as `root` honestly. However, it is inside a container. So we shouldn't be too worried about this. Just a reminder from other developers that we should start migrating to a non-`root` user. In the interim, we use the easy fix to get around this new behavior of the Jupyter Notebook server.


Raised issue ( https://github.com/jakirkham/docker_centos_drmaa_conda/issues/34 ) to migrate to a non-`root` user.