### PR TITLE
Fix tini's path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,4 +71,4 @@ RUN rm -f /tmp/test.sh && \
     rm /tmp/test.sh
 
 WORKDIR /nanshe_workflow
-ENTRYPOINT [ "/usr/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" ]


### PR DESCRIPTION
As we have switched to the conda-forge package for `tini`, we need to update the path for running it.

xref: https://github.com/jakirkham/docker_centos_drmaa_conda/pull/39