### PR TITLE
Enable ExecuteTime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python${PYTHON_VERSION} -m ipykernel install && \
         python${PYTHON_VERSION} -m ipyparallel.apps.ipclusterapp nbextension enable && \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
+        python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
         conda${PYTHON_VERSION} remove -qy -n _build --all || true && \
         conda${PYTHON_VERSION} remove -qy -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python${PYTHON_VERSION} -m ipyparallel.apps.ipclusterapp nbextension enable && \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
         python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \
+        python${PYTHON_VERSION} -m jupyter nbextension enable execute_time/ExecuteTime && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
         conda${PYTHON_VERSION} remove -qy -n _build --all || true && \
         conda${PYTHON_VERSION} remove -qy -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all && \


### PR DESCRIPTION
Ensures that Jupyter contrib's extensions are installed in the Docker image. Also enables ExecuteTime from Jupyter contrib so that we can get time stamps and run time duration in the workflow.