### PR TITLE
Clear execution times when clearing output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
         python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \
         python${PYTHON_VERSION} -m jupyter nbextension enable execute_time/ExecuteTime && \
+        python${PYTHON_VERSION} -c "from notebook.services.config import ConfigManager as C; C().update('notebook', {'ExecuteTime': {'clear_timings_on_clear_output': True}})" && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
         conda${PYTHON_VERSION} remove -qy -n _build --all || true && \
         conda${PYTHON_VERSION} remove -qy -n _build_placehold_placehold_placehold_placehold_placehold_placeh --all && \


### PR DESCRIPTION
Makes sure that the execution times are also cleared when clearing the notebook's output (e.g. "Kernel" > "Restart & Clear Output").