### PR TITLE
Set OPENBLAS_NUM_THREADS to 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda${PYTHON_VERSION} clean -tipsy ; \
     done
 
+ENV OPENBLAS_NUM_THREADS=1
+
 RUN python3 -m IPython profile create --parallel && \
     echo -e "import os\n\n\nc = get_config()\n\nc.IPClusterEngines.n = int(os.environ[\"CORES\"]) - 1" > /root/.ipython/profile_default/ipcluster_config.py && \
     echo -e "c = get_config()\n\nc.HubFactory.ip = '*'\nc.HubFactory.engine_ip = '*'\nc.HubFactory.db_class = \"SQLiteDB\"" > /root/.ipython/profile_default/ipcontroller_config.py && \


### PR DESCRIPTION
Make sure that OpenBLAS is restricted to 1 thread. As parallelism is handled by having multiple Python processes performing computations on different chunks, there is no need for this sort of parallelism to clash with lower level parallelism like OpenBLASes. After all the Python process parallelism allows the greatest degree of parallelism for the longest period of time whereas OpenBLAS parallelism is basically transient as it only exists for very specific operations in only some steps.