### PR TITLE
Use `nanshe/nanshe_notebook:sge`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nanshe/nanshe_notebook:latest
+FROM nanshe/nanshe_notebook:sge
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 ADD nanshe_workflow /nanshe_workflow

--- a/startup_nanshe_workflow.py
+++ b/startup_nanshe_workflow.py
@@ -395,7 +395,7 @@ def main(*argv):
 
     machine_name = "nanshe-workflow"
     workflow_name = "nanshe_workflow"
-    parent_image_name = "nanshe/nanshe_notebook:latest"
+    parent_image_name = "nanshe/nanshe_notebook:sge"
     image_name = "nanshe/nanshe_workflow:latest"
     docker_dir = os.path.dirname(os.path.abspath(__file__))
     workflow_dir = os.path.join(docker_dir, workflow_name)

--- a/startup_nanshe_workflow.py
+++ b/startup_nanshe_workflow.py
@@ -395,8 +395,8 @@ def main(*argv):
 
     machine_name = "nanshe-workflow"
     workflow_name = "nanshe_workflow"
-    parent_image_name = "nanshe/nanshe_notebook"
-    image_name = "nanshe/nanshe_workflow"
+    parent_image_name = "nanshe/nanshe_notebook:latest"
+    image_name = "nanshe/nanshe_workflow:latest"
     docker_dir = os.path.dirname(os.path.abspath(__file__))
     workflow_dir = os.path.join(docker_dir, workflow_name)
     docker_workdir = "/" + workflow_name


### PR DESCRIPTION
As SGE support will be removed from the `nanshe/nanshe_notebook:latest` ( https://github.com/nanshe-org/docker_nanshe/pull/26 ), use the `nanshe/nanshe_notebook:sge` image, which will continue to have and support SGE. This way the existing workflow image will continue to operate correctly.