### PR TITLE
Check the Docker image and tag are present

### DIFF
--- a/startup_nanshe_workflow.py
+++ b/startup_nanshe_workflow.py
@@ -609,7 +609,19 @@ def main(*argv):
             pass
 
     with DockerVM(shutdown=shutdown) as vm:
-        if update or (image_name not in vm.images["REPOSITORY"]):
+        try:
+            image_repo, image_tag = image_name.split(":")
+        except ValueError:
+            image_repo, = image_name.split(":")
+            image_tag = "latest"
+
+        found_image = False
+        for n, t in zip(vm.images["REPOSITORY"], vm.images["TAG"]):
+            if n == image_repo and t == image_tag:
+                found_image = True
+                break
+
+        if update or not found_image:
             vm.pull(parent_image_name)
             if not build:
                 try:


### PR DESCRIPTION
Previously only the image name was checked in the Docker image list. However this doesn't validate the specified tag is present. Nor does it handle cases where the image's tag is also specified with the image name. This corrects that issue by separating the image name from the image tag (if there is one) using `latest` otherwise and checking that both are found together in the image listing.