### PR TITLE
Enable `execute_time` in system prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         python${PYTHON_VERSION} -m jupyter trust /nanshe_workflow/nanshe_ipython.ipynb && \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
         python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \
-        python${PYTHON_VERSION} -m jupyter nbextension enable execute_time/ExecuteTime && \
+        python${PYTHON_VERSION} -m jupyter nbextension enable --sys-prefix execute_time/ExecuteTime && \
         python${PYTHON_VERSION} -c "from notebook.services.config import ConfigManager as C; C().update('notebook', {'ExecuteTime': {'clear_timings_on_clear_output': True}})" && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \
         conda${PYTHON_VERSION} clean -tipsy ; \


### PR DESCRIPTION
When calling `jupyter nbextension enable`, it by default will enable the extension in the home directory. However this is problematic when trying to run the Jupyter Notebook in a singularity container as it lacks permissions to `root`'s home directory. To fix this issue, we add the `--sys-prefix` argument. This seems to have the correct behavior of enabling the `execute_time` extension in the `PREFIX/etc` under the current `conda` install.