### PR TITLE
Drop unneeded Jupyter configuration steps (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda${PYTHON_VERSION} update -qy --use-local -n root --all && \
         pip${PYTHON_VERSION} install -e /nanshe_workflow && \
         python${PYTHON_VERSION} -m jupyter trust /nanshe_workflow/nanshe_ipython.ipynb && \
-        python${PYTHON_VERSION} -m ipyparallel.apps.ipclusterapp nbextension enable && \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
         python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \
         python${PYTHON_VERSION} -m jupyter nbextension enable execute_time/ExecuteTime && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda${PYTHON_VERSION} update -qy --use-local -n root --all && \
         pip${PYTHON_VERSION} install -e /nanshe_workflow && \
         python${PYTHON_VERSION} -m jupyter trust /nanshe_workflow/nanshe_ipython.ipynb && \
-        python${PYTHON_VERSION} -m ipykernel install && \
         python${PYTHON_VERSION} -m ipyparallel.apps.ipclusterapp nbextension enable && \
         python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
         python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/46 ) for SGE

First drops the install of the Python 2/3 kernels to the notebook (this is already handled in the base image `nanshe/nanshe_notebook`).

Second drops the install of the `ipyparallel` extension to the Jupyter notebook. This was never even used when `ipyparallel` was still used in the notebook as the cluster was started directly within the notebook.