### PR TITLE
Reorganization of test environment steps (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ RUN rm -f /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
     echo -e "set -e" >> /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
+    echo -e "export CORES=2" >> /tmp/test.sh && \
+    echo -e "" >> /tmp/test.sh && \
     echo -e "for PYTHON_VERSION in 2 3; do" >> /tmp/test.sh && \
-    echo -e "    export CORES=2 " >> /tmp/test.sh && \
     echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \
     echo -e "    python${PYTHON_VERSION} setup.py test && " >> /tmp/test.sh && \
     echo -e "    (qdel -f -u root || true) && " >> /tmp/test.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN rm -f /tmp/test.sh && \
     echo -e "set -e" >> /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
     echo -e "export CORES=2" >> /tmp/test.sh && \
+    echo -e "export NB_EXE_TIMEOUT=30" >> /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
     echo -e "for PYTHON_VERSION in 2 3; do" >> /tmp/test.sh && \
     echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN rm -f /tmp/test.sh && \
     echo -e "set -e" >> /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
     echo -e "for PYTHON_VERSION in 2 3; do" >> /tmp/test.sh && \
-    echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \
     echo -e "    export CORES=2 " >> /tmp/test.sh && \
+    echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \
     echo -e "    python${PYTHON_VERSION} setup.py test && " >> /tmp/test.sh && \
     echo -e "    (qdel -f -u root || true) && " >> /tmp/test.sh && \
     echo -e "    qstat && " >> /tmp/test.sh && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/52 ) for SGE.

Moves environment variables used in testing out of the `for`-loop for Python versions. Thus allowing them to be reused across cases. Also explicitly sets the `nbconvert` timeout.