### PR TITLE
Improve the workflow install step

### DIFF
--- a/install_workflows.sh
+++ b/install_workflows.sh
@@ -31,7 +31,16 @@ where:
 fi
 
 
+echo "Copying workflows from source to destination..."
 for each_workflow in $(find "$1" -name "*.ipynb");
 do
-    cp -n "$each_workflow" "$2"
+    each_workflow="$(basename "$each_workflow")"
+    if [[ -e "$2/$each_workflow" ]];
+    then
+        echo "    Skipped: "$each_workflow""
+    else
+        cp "$1/$each_workflow" "$2"
+        echo "    Copied:  "$each_workflow""
+    fi
 done
+echo "Completed copying of workflows."

--- a/install_workflows.sh
+++ b/install_workflows.sh
@@ -29,5 +29,5 @@ fi
 
 for each_workflow in $(find "$1" -name "*.ipynb");
 do
-    mv -n "$each_workflow" "$2"
+    cp -n "$each_workflow" "$2"
 done

--- a/install_workflows.sh
+++ b/install_workflows.sh
@@ -27,7 +27,7 @@ where:
 fi
 
 
-for each_workflow in $(find $1 -name "*.ipynb");
+for each_workflow in $(find "$1" -name "*.ipynb");
 do
-    mv -n $each_workflow $2
+    mv -n "$each_workflow" "$2"
 done

--- a/install_workflows.sh
+++ b/install_workflows.sh
@@ -13,6 +13,10 @@ then
     echo "Requires exactly two parameters."
     HELP=true
     EXIT=64
+elif [ "$(cd "$1" && pwd)" == "$(cd "$2" && pwd)" ];
+then
+    echo "Skipping copying workflows as source and destination are the same."
+    exit 0
 fi
 
 if [ $HELP = true ];

--- a/install_workflows.sh
+++ b/install_workflows.sh
@@ -10,7 +10,7 @@ then
     HELP=true
 elif [ $# -ne 2 ];
 then
-    echo "Requires exactly one parameter."
+    echo "Requires exactly two parameters."
     HELP=true
     EXIT=64
 fi


### PR DESCRIPTION
Makes some improvements to the `install_workflows.sh` script used to install the workflows when running `startup_nanshe_workflow.py`. Mainly tries to provide better information about what got installed or not as well as why. Also avoids running the script if the source and destination are the same. This is done with an eye towards using this in the entrypoint script as noted in issue ( https://github.com/nanshe-org/docker_nanshe_workflow/issues/48 ).