### PR TITLE
Copy notebooks over in the entrypoint (for SGE)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -66,9 +66,6 @@ nanshe_workflow/log.client
 nanshe_workflow/log.scheduler
 nanshe_workflow/log.workers
 
-# Workflow installation script.
-install_workflows.sh
-
 # Ignore IDE project files.
 .idea/
 nanshe_workflow/.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN sed -i.bak "s/..\/..\/..\/nanshe_workflow/../g" /nanshe_workflow/.git/config
     cd /nanshe_workflow && git update-index -q --refresh && cd /
 
 ADD entrypoint.sh /usr/share/docker/entrypoint_3.sh
+ADD install_workflows.sh /usr/share/docker/install_workflows.sh
 
 RUN for PYTHON_VERSION in 2 3; do \
         cd /nanshe_workflow && git update-index -q --refresh && cd / && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,8 @@
 # Make sure repo is clean.
 git update-index -q --refresh
 
+# Install the workflows into the current working directory.
+/usr/share/docker/install_workflows.sh /nanshe_workflow "$(pwd)"
+
 
 exec "$@"

--- a/startup_nanshe_workflow.py
+++ b/startup_nanshe_workflow.py
@@ -634,19 +634,7 @@ def main(*argv):
 
         mounted_directory = ""
         if directory is not None:
-            subprocess.check_call([
-                "docker",
-                "run",
-                "-it",
-                "--rm",
-                "--volume=" + docker_dir + ":" + "/mnt/docker",
-                "--volume=" + directory + ":" + "/mnt/ext",
-                "--entrypoint=/mnt/docker/install_workflows.sh",
-                image_name,
-                ".",
-                "/mnt/ext"
-            ])
-            print("Installed workflows into directory: \"%s\"" % directory)
+            print("Installing workflows into directory: \"%s\"" % directory)
             mounted_directory = "/root/work"
         elif mount_workflow:
             directory = workflow_dir


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/60 ) for SGE.

Fixes https://github.com/nanshe-org/docker_nanshe_workflow/issues/48

Packages the `install_workflows.sh` script in the Docker container and calls it in the entrypoint script to ensure the notebooks are copied over to the user's working directory. If the notebooks are not already present or the user is doing development, the notebooks are not copied.

Also fixes a few minor things like the error message for the wrong number of arguments.