### PR TITLE
Pin distributed to 1.21.0 (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ADD entrypoint.sh /usr/share/docker/entrypoint_3.sh
 ADD install_workflows.sh /usr/share/docker/install_workflows.sh
 
 RUN for PYTHON_VERSION in 2 3; do \
+        echo "distributed 1.21.0" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         cd /nanshe_workflow && git update-index -q --refresh && cd / && \
         (mv /nanshe_workflow/.git/shallow /nanshe_workflow/.git/shallow-not || true) && \
         conda${PYTHON_VERSION} build /nanshe_workflow/nanshe_workflow.recipe && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/66 ) for SGE.

Currently we are affected by a `distributed` bug ( https://github.com/dask/distributed/issues/1792 ) in version 1.21.0 on the cluster, which causes workers to not be registered correctly. This results in workers terminating early and resources not being correctly determined. While the resolution to this issue is being pursued, pin `distributed` to the last known working version (1.21.0) in the Docker image build. This should produce an image that works as expected on the cluster for the interim.