### PR TITLE
Drop explicitly setting `NB_EXE_TIMEOUT`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN rm -f /tmp/test.sh && \
     echo -e "set -e" >> /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
     echo -e "export CORES=2" >> /tmp/test.sh && \
-    echo -e "export NB_EXE_TIMEOUT=30" >> /tmp/test.sh && \
     echo -e "" >> /tmp/test.sh && \
     echo -e "for PYTHON_VERSION in 2 3; do" >> /tmp/test.sh && \
     echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \


### PR DESCRIPTION
Revert commit ( https://github.com/nanshe-org/docker_nanshe_workflow/commit/9df407f024e3f7dba55045eaddc08d805e28798f )

Simply rely on the timeout default set in the workflow tests for the moment. Currently 30s is already the default timeout in the present release of the workflow. It will bump up to 60s in the upcoming release.

xref: https://github.com/nanshe-org/docker_nanshe_workflow/pull/52
