### PR TITLE
Drop unneeded Jupyter extension install steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda${PYTHON_VERSION} update -qy --use-local --all && \
         pip${PYTHON_VERSION} install -e /nanshe_workflow && \
         python${PYTHON_VERSION} -m jupyter trust /nanshe_workflow/nanshe_ipython.ipynb && \
-        python${PYTHON_VERSION} -m notebook.nbextensions enable --sys-prefix --py widgetsnbextension && \
-        python${PYTHON_VERSION} -m jupyter contrib nbextension install --sys-prefix && \
         python${PYTHON_VERSION} -m jupyter nbextension enable --sys-prefix execute_time/ExecuteTime && \
         python${PYTHON_VERSION} -c "from notebook.services.config import ConfigManager as C; C().update('notebook', {'ExecuteTime': {'clear_timings_on_clear_output': True}})" && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/work/* && \


### PR DESCRIPTION
Previously we had manually run extension install steps (after doing the `conda install` of their packages where the post-link steps should have handled this issue). However the `conda` packages with a modern version of `conda` seem to behave fine. Plus this is done upstream of the workflow container in the notebook container. So there is no need to explicitly run these configuration steps in the workflow container. Should cutdown noise at this level both in logs and in build layers (generally simplifying maintenance).

xref: https://github.com/nanshe-org/docker_nanshe_notebook/pull/23