### PR TITLE
Move entrypoint scripts around tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN rm -f /tmp/test.sh && \
     echo -e "    . /opt/conda${PYTHON_VERSION}/etc/profile.d/conda.sh && " >> /tmp/test.sh && \
     echo -e "    conda activate base && " >> /tmp/test.sh && \
     echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \
-    echo -e "    python${PYTHON_VERSION} setup.py test && " >> /tmp/test.sh && \
+    echo -e "    /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh python${PYTHON_VERSION} setup.py test && " >> /tmp/test.sh && \
     echo -e "    git clean -fdx && " >> /tmp/test.sh && \
     echo -e "    rm -rf ~/ipcontroller.o* && " >> /tmp/test.sh && \
     echo -e "    rm -rf ~/ipcontroller.e* && " >> /tmp/test.sh && \
@@ -63,8 +63,6 @@ RUN rm -f /tmp/test.sh && \
     echo -e "    rm -rf ~/ipengine.e* && " >> /tmp/test.sh && \
     echo -e "    conda deactivate ; " >> /tmp/test.sh && \
     echo -e "done" >> /tmp/test.sh && \
-    /usr/share/docker/entrypoint.sh \
-    /usr/share/docker/entrypoint_2.sh \
     /tmp/test.sh && \
     rm /tmp/test.sh
 


### PR DESCRIPTION
Backport PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/87 ) for non-SGE builds.

Simply call `python setup.py test` through the entrypoint scripts. Mainly a backport from the `sge` branch. Still this seems to be a working strategy and it helps the maintenance effort to keep the two branches in sync.