### PR TITLE
Override `CONDA_PKGS_DIRS` for `conda-build` (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda activate base && \
         cd /nanshe_workflow && git update-index -q --refresh && cd / && \
         (mv /nanshe_workflow/.git/shallow /nanshe_workflow/.git/shallow-not || true) && \
+        export CONDA_PKGS_DIRS="/opt/conda${PYTHON_VERSION}/conda-bld/bld_pkgs" && \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
+        unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/93 ) for SGE.

It seems adding/remove hardlinks to files causes some issues for Singularity when trying to convert a Docker image. Given `conda` does create hard links to packages' files between environments to cutdown on disk usage, it seems that this might be part of the problem.

This has been validated by showing that `conda clean` when given the `-p` option can result in an image that cannot be converted. Removal of the same `-p` option from the `conda clean` command allows the image to be converted without issues. However `conda clean` with the `-p` option is already used profusely throughout our stack. So that alone does not seem to be the cause of the issue (even though avoiding it in this case does seem to provide a workaround).

The one other thing we are doing in this image that other images are not doing is building a `conda` package with `conda-build`. This would result in creating another `conda` environment outside of `base` (again something that we are not usually doing), which would introduce hard links. Given some of the packages that had problems were part of a basic `python` install, this further corroborates the fact that the `conda-build` step is involved due to sharing package contents in the new environment.

A sensible workaround to this issue would be to have `conda` and `conda-build` use a different directory to store packages downloaded for the build only. This avoids messing with the packages in `base` at all as this would be a totally separate stack of `conda` packages. So there will be no need to hard link to packages used by `base`. Not to mention as this package cache is only picked for temporary use during the build, it is not visible to `conda` after the build is complete. Thus avoiding accidentally picking up these new packages and including them in `base`. To aid in cleanup and general maintenance, this package cache is placed under the `conda-bld` directory. That way it is automatically cleaned up right along with the subsequent clean up steps for the `conda-bld` directory.

ref: https://conda.io/docs/user-guide/configuration/use-condarc.html#specify-package-directories-pkgs-dirs