### PR TITLE
Replace `python3` with `python` (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ RUN rm -f /tmp/test.sh && \
     rm /tmp/test.sh
 
 WORKDIR /nanshe_workflow
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "/usr/share/docker/entrypoint_3.sh", "python3", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "/usr/share/docker/entrypoint_3.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" ]


### PR DESCRIPTION
Backport of PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/95 ) for SGE.

As activation of the `conda` environment now works correctly, there is no need to specify that `python3` should be used. Instead by simply specifying `python`, the right `python` from the active `conda` environment (which will be the one with Python 3) will be used. So just use `python` and let `conda` find the correct one.