### PR TITLE
Pin distributed to 1.21.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
+        echo "distributed 1.21.6" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \


### PR DESCRIPTION
Appears that there are some issues shutting down Distributed Client's in 1.21.8, so pin to 1.21.6 so that we can finish the rebuild of the stack for now. Can drop the pinning once the upstream issues are fixed.

xref: https://github.com/dask/distributed/issues/1963
ref: https://quay.io/repository/nanshe/nanshe_workflow/build/32a365f4-6678-468e-8acc-d849aaff41e1