### PR TITLE
Unpin distributed (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
-        echo "distributed 1.21.6" >> "/opt/conda${PYTHON_VERSION}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/102 ) for SGE.
Reverts PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/98 )

Remove the `distributed` pin on version `1.21.6` as `distributed` version `1.22.0` includes fixes to the problems we are running into. Plus we would like to include the latest released `dask` and `distributed` versions in the Docker image.