### PR TITLE
Pin Bokeh to 0.12.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
+        echo "bokeh 0.12.16" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \


### PR DESCRIPTION
As the Dask Distributed Dashboard only works reliably with Bokeh 0.12.* and not yet with Bokeh 0.13.0+, pin the version of Bokeh used to 0.12.16. This can be unpinned once the Dask Distributed Dashboard works with Bokeh 0.13.0+.