### PR TITLE
Unpin Bokeh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
-        echo "bokeh 0.12.16" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \


### PR DESCRIPTION
Newer versions of Distributed work with Bokeh 0.13.0+ and in fact require Bokeh 0.13.0 at a minimum. Further newer versions of Dask require a newer version of Distributed. So requiring an older version of Bokeh also holds back Dask and Distributed. Given the scheduler display bug has been fixed with Bokeh 0.13.0 in Distributed 1.23.0, go ahead and release this Bokeh pin. Thus also allowing newer versions of Dask and Distributed to be installed.