### PR TITLE
Change `ip` argument from `*` to `0.0.0.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ RUN rm -f /tmp/test.sh && \
     rm /tmp/test.sh
 
 WORKDIR /nanshe_workflow
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=*" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0" ]


### PR DESCRIPTION
As Jupyter Notebook 5.7.0 changed some behavior, which has caused `--ip=*` to fail, switch to `--ip=0.0.0.0`. This has the same semantic meaning; though, has the benefit of working Jupyter Notebook pre-5.7.0 and 5.7.0+.