### PR TITLE
Pin Bokeh to 0.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
+        echo "bokeh 0.13.0" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         echo "dask-core 0.19.4" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \


### PR DESCRIPTION
Some changes in Bokeh 1.0.0 appear to have broken the interactive ROI trace plot. So go ahead and pin Bokeh to the last known working version, which is Bokeh 0.13.0, to get things working again in the container. Can relax once the underlying issue is fixed.