### PR TITLE
Pin Distributed to 1.23.3 (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
         echo "bokeh 0.13.0" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         echo "dask-core 0.19.4" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
+        echo "distributed 1.23.3" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/118 ) for SGE.

In Distributed 1.24.0, the Joblib backend has been removed from the Distributed codebase (it's in Joblib now both on its own and in the copy vendored in scikit-learn). This breaks the workflow currently. While it is a simple matter to fix this, it hasn't been fixed yet. So for now pin Distributed to the last known working version (i.e. 1.23.3) to bypass this issue. Can drop this pinning once the workflow has been updated to handle this.