### PR TITLE
Release 2.12.7 (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
         echo "bokeh 0.13.0" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         echo "dask-core 0.19.4" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
-        echo "distributed 1.23.3" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
-        echo "dask-core 0.19.4" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN for PYTHON_VERSION in 2 3; do \
         conda build /nanshe_workflow/nanshe_workflow.recipe && \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
-        echo "bokeh 0.13.0" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         echo "dask-core 0.19.4" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned" && \
         conda install -qy --use-local nanshe_workflow && \
         conda update -qy --use-local --all && \


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/120 ) for SGE.

Releases the 2.12.7 version of the workflow.

Revert https://github.com/nanshe-org/docker_nanshe_workflow/pull/115
Revert https://github.com/nanshe-org/docker_nanshe_workflow/pull/117
Revert https://github.com/nanshe-org/docker_nanshe_workflow/pull/119