### PR TITLE
Drop extra `conda update` calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,7 @@ RUN for PYTHON_VERSION in 2 3; do \
         unset CONDA_PKGS_DIRS && \
         (mv /nanshe_workflow/.git/shallow-not /nanshe_workflow/.git/shallow || true) && \
         conda install -qy --use-local nanshe_workflow && \
-        conda update -qy --use-local --all && \
         conda remove -qy nanshe_workflow && \
-        conda update -qy --use-local --all && \
         conda build purge && \
         rm -rf /opt/conda${PYTHON_VERSION}/conda-bld/* && \
         conda clean -tipsy && \


### PR DESCRIPTION
There is no real need for these `conda update` calls any more as the Conda solver has improved. In fact more often than not, additional `conda update` calls result in changes that break the environment (e.g. updating something even if it means breaking the environment by pulling in older unpinned packages). This happened recently for us with `tornado`, but it has happened before with other things.