### PR TITLE
Docker ignore .git keep nanshe_workflow submodule (for SGE)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,25 +1,8 @@
 # Git
 .gitignore
 .gitmodules
-.git/COMMIT_EDITMSG
-.git/FETCH_HEAD
-.git/HEAD
-.git/ORIG_HEAD
-.git/branches
-.git/commondir
-.git/config
-.git/description
-.git/hooks
-.git/index
-.git/info
-.git/logs
-.git/objects
-.git/packed-refs
-.git/refs
-.git/remotes
-.git/shallow
-.git/sharedindex*
-.git/worktrees
+.git
+!.git/modules/nanshe_workflow
 nanshe_workflow/.git
 
 # CI


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/issues/130 ) for SGE.

Use the exclusion feature added in Docker 1.7.0 to simplify the `.dockerignore` file. Now it just ignores all of `.git/`, but excludes `.git/modules/nanshe_workflow` so as to keep the git repo for the `nanshe_workflow` submodule only.