### PR TITLE
Force Dask Distributed to use spawn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN for PYTHON_VERSION in 2 3; do \
     done
 
 ENV OPENBLAS_NUM_THREADS=1
+ENV DASK_DISTRIBUTED__WORKER__MULTIPROCESSING_METHOD="spawn"
 
 RUN rm -f /tmp/test.sh && \
     touch /tmp/test.sh && \


### PR DESCRIPTION
Sets an environment variable to ensure that Dask Distributed uses spawn to start workers. This seems to avoid some segmentation faults that plagued the dictionary learning step when OpenBLAS was running. As forking and OpenBLAS have had problems in the past, staying clear of forking for that step should avoid some issues.