### PR TITLE
Handle nanshe_notebook entrypoint script (for SGE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN export INSTALL_CONDA_PATH="/opt/conda${PYTHON_VERSION}" && \
     cd /nanshe_workflow && git update-index -q --refresh && cd / && \
     conda deactivate
 
-ADD entrypoint.sh /usr/share/docker/entrypoint_3.sh
+ADD entrypoint.sh /usr/share/docker/entrypoint_4.sh
 ADD install_workflows.sh /usr/share/docker/install_workflows.sh
 
 RUN for PYTHON_VERSION in 2 3; do \
@@ -57,7 +57,7 @@ RUN rm -f /tmp/test.sh && \
     echo -e "    . /opt/conda${PYTHON_VERSION}/etc/profile.d/conda.sh && " >> /tmp/test.sh && \
     echo -e "    conda activate base && " >> /tmp/test.sh && \
     echo -e "    cd /nanshe_workflow && " >> /tmp/test.sh && \
-    echo -e "    /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh /usr/share/docker/entrypoint_3.sh python setup.py test && " >> /tmp/test.sh && \
+    echo -e "    /usr/share/docker/entrypoint.sh /usr/share/docker/entrypoint_2.sh /usr/share/docker/entrypoint_3.sh /usr/share/docker/entrypoint_4.sh python setup.py test && " >> /tmp/test.sh && \
     echo -e "    (qdel -f -u root || true) && " >> /tmp/test.sh && \
     echo -e "    qstat && " >> /tmp/test.sh && \
     echo -e "    service sge_execd stop && " >> /tmp/test.sh && \
@@ -73,4 +73,4 @@ RUN rm -f /tmp/test.sh && \
     rm /tmp/test.sh
 
 WORKDIR /nanshe_workflow
-ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "/usr/share/docker/entrypoint_3.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0" ]
+ENTRYPOINT [ "/opt/conda/bin/tini", "--", "/usr/share/docker/entrypoint.sh", "/usr/share/docker/entrypoint_2.sh", "/usr/share/docker/entrypoint_3.sh", "/usr/share/docker/entrypoint_4.sh", "python", "-m", "notebook", "--allow-root", "--no-browser", "--ip=0.0.0.0" ]


### PR DESCRIPTION
Backports PR ( https://github.com/nanshe-org/docker_nanshe_workflow/pull/134 ) for SGE.

Make sure to include `nanshe_notebook`'s entrypoint script in the `ENTRYPOINT`. Also rename `nanshe_workflow`'s entrypoint script to avoid conflicting with `nanshe_notebook`'s.

xref: https://github.com/nanshe-org/docker_nanshe_notebook/pull/40